### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ data/
 *.[tT][xX][tT]
 
 # Excel files #
-*.[xX][lL][sS][xXmMtT]?
+*.[xX][lL][sS]*
 
 # SPSS formats #
 *.[sS][aA][vV]


### PR DESCRIPTION
Just had a practical example where the ? at the end of a selection of characters didn't work the way we think it should. So I've swapped out the final selection of characters for the excel file extensions and added the * instead, which should just block any file beginning with ".xls". If there are ever any exceptions to this rule (unlikely I think) then we can always just add a wee exception for it. Think that can be done with ! but not sure!